### PR TITLE
Update src/com/era7/bioinfo/annotation/gb/ExportGenBankFiles.java

### DIFF
--- a/src/com/era7/bioinfo/annotation/gb/ExportGenBankFiles.java
+++ b/src/com/era7/bioinfo/annotation/gb/ExportGenBankFiles.java
@@ -302,7 +302,7 @@ public class ExportGenBankFiles implements Executable {
         //in this case the format is a bit more restrictive so we have to write
         //words in specific positions paying also attention to their separators
         String locusLineSt = "";
-        locusLineSt += GBCommon.LOCUS_STR + getWhiteSpaces(6);
+        locusLineSt += GBCommon.LOCUS_STR + getWhiteSpaces(7);
 //  --> This is how things were done before
 //        if (genBankXml.getLocusName().length() > 16) {
 //            locusLineSt += genBankXml.getLocusName().substring(0, 16);


### PR DESCRIPTION
Locus line has one too few spaces after 'LOCUS' before the ID, so that it does not line up with definition/accession/etc. This causes the files to not load properly into Biopython. Additionally adding the linear/circular annotation after the molecule type (DNA) is not genbank-spec, and causes a warning.
